### PR TITLE
Allow Guzzle 7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
     },
     "require": {
         "php": "^5.6|^7.0",
-        "guzzlehttp/guzzle": "^6.0",
+        "guzzlehttp/guzzle": "^6.0|^7.0",
         "paragonie/random_compat": "^1|^2|^9.99"
     },
     "require-dev": {


### PR DESCRIPTION
Well, the title says it all (:


Thanks for the awesome libraries :+1: 

Just out of curiosity, I think there might be some code duplication from thephpleague/oauth2-client ( e.g. [League\OAuth2\Client\Grant\AbstractGrant](https://github.com/thephpleague/oauth2-client/blob/master/src/Grant/AbstractGrant.php) and [Awx\OAuth2\Client\Grant\AbstractGrant](https://github.com/sdwru/oauth2-awx/blob/master/src/Grant/AbstractGrant.php) are purpose-wise identical, but i did not investigate further...)

Was this done for the custom AWX implementation of Oauth or some other reason I am not comprehending?
I haven't seen a requirement for the original oauth2-client library even if the README states it is based on thephpleague/oauth2-client library, am I missing something?